### PR TITLE
Fixing gist URLs

### DIFF
--- a/internal/app/keyword_scan.go
+++ b/internal/app/keyword_scan.go
@@ -46,12 +46,7 @@ func ScanAndPrintResult(client *http.Client, repo RepoSearchResult) {
 	if scannedRepos[repo.Repo] {
 		return
 	}
-	var base string
-	if repo.Source == "repo" {
-		base = "https://raw.githubusercontent.com"
-	} else if repo.Source == "gist" {
-		base = "https://gist.githubusercontent.com"
-	}
+	base := GetRawURLForSearchResult(repo)
 	data, err := DownloadRawFile(client, base, repo)
 	if err != nil {
 		log.Fatal(err)
@@ -68,7 +63,8 @@ func ScanAndPrintResult(client *http.Client, repo RepoSearchResult) {
 
 	if len(matches) > 0 {
 		if !GetFlags().ResultsOnly {
-			color.Green("[https://github.com/" + repo.Repo + "]")
+			resultRepoURL := GetRepoURLForSearchResult(repo)
+			color.Green("[" + resultRepoURL + "]")
 		}
 		for _, result := range matches {
 			if result.KeywordType == "apiKey" {
@@ -268,7 +264,7 @@ func PrintResultLink(result RepoSearchResult, match Match) {
 		if file == "" {
 			file = result.File
 		}
-		color.New(color.Faint).Println("https://github.com/" + result.Repo + "/blob/master/" + file)
+		color.New(color.Faint).Println(result.URL)
 	}
 }
 

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -20,6 +20,7 @@ type RepoSearchResult struct {
 	Raw           string
 	Source        string
 	Query         string
+	URL           string
 	searchOptions *SearchOptions
 }
 
@@ -172,6 +173,7 @@ func SearchGitHub(query string, options SearchOptions, client *http.Client, resu
 							Raw:    element[2] + "/master/" + element[4],
 							Source: "repo",
 							Query:  query,
+							URL:    "https://github.com/" + element[2] + "/blob/" + element[3],
 						})
 					}
 				}
@@ -266,6 +268,7 @@ func SearchGist(query string, options SearchOptions, client *http.Client, result
 					Raw:    GetRawGistPage(client, element[1]),
 					Source: "gist",
 					Query:  query,
+					URL:    "https://gist.github.com/" + element[1],
 				})
 			}
 		}

--- a/internal/app/util.go
+++ b/internal/app/util.go
@@ -40,3 +40,26 @@ func CheckErr(err error) {
 		log.Fatal(err)
 	}
 }
+
+// GetRepoURLForSearchResult returns the URL of the repo depending on
+// RepoSearchResult source
+func GetRepoURLForSearchResult(repo RepoSearchResult) string {
+	if repo.Source == "repo" {
+		return "https://github.com/" + repo.Repo
+	} else if repo.Source == "gist" {
+		return "https://gist.github.com/" + repo.Repo
+	}
+	// Left this way in case other Source values ever exist
+	return ""
+}
+
+// GetRawURLForSearchResult returns a raw data URL for a RepoSearchResult
+func GetRawURLForSearchResult(repo RepoSearchResult) string {
+	if repo.Source == "repo" {
+		return "https://raw.githubusercontent.com"
+	} else if repo.Source == "gist" {
+		return "https://gist.githubusercontent.com"
+	}
+	// Left this way in case other Source values ever exist
+	return ""
+}


### PR DESCRIPTION
Fixes #17 

## What's Changed
* Added a new field in `RepoSearchResult` to capture the URL of the search result (to be used later down the line)
* Added a few helper functions to proper pick the correct URL when deciding between a repo and  a gist
   * Used these functions in the printing logic

I'm not normally a Golang dev, so pardon my stupidity if anything seems off. Tested locally with success but also seeking some feedback as well. Thanks!