### PR TITLE
Adding support for otp codes automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ More information on methodologies is available in the [accompanying blog post](h
 ## Setup
 
 1. Download the [latest release of GitHound](https://github.com/tillson/git-hound/releases)
-2. Create a `./config.yml` or `~/.githound/config.yml` with your GitHub username and password. See [config.example.yml](config.example.yml).
+2. Create a `./config.yml` or `~/.githound/config.yml` with your GitHub username and password. Optionally, include your 2FA TOTP seed. See [config.example.yml](config.example.yml).
    1. If it's your first time using the account on the system, you may receieve an account verification email.
 3. `echo "tillsongalloway.com" | git-hound`
 
@@ -67,6 +67,7 @@ For files that encode secrets, decodes base64 strings and searches the encoded s
 * `--no-files` - Don't flag interesting file extensions
 * `--only-filtered` - Only search filtered queries (languages)
 * `--debug` - Print verbose debug messages.
+* `--otp-code` - Github account 2FA code for sign-in. (Only use if you have authenticator 2FA setup on your Github account)
 
 ## User feedback
 These are discussions about how people use GitHound in their workflows and how we can GitHound to fufill those needs. If you use GitHound, consider leaving a note in one of the active issues.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func InitializeFlags() {
 	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().NoGists, "no-gists", false, "Don't search Gists")
 	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().NoRepos, "no-repos", false, "Don't search repos")
 	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().Debug, "debug", false, "Enables verbose debug logging.")
+	rootCmd.PersistentFlags().StringVar(&app.GetFlags().OTPCode, "otp-code", "", "Github account 2FA token used for sign-in. (Only use if you have 2FA enabled on your account via authenticator app)")
 }
 
 var rootCmd = &cobra.Command{
@@ -72,6 +73,7 @@ var rootCmd = &cobra.Command{
 		client, err := app.LoginToGitHub(app.GitHubCredentials{
 			Username: viper.GetString("github_username"),
 			Password: viper.GetString("github_password"),
+			OTP:      viper.GetString("github_totp_seed"),
 		})
 		// if client.
 		if err != nil {

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,3 +1,5 @@
 # Required
 github_username: tillson
 github_password: a8ueifjq4jkasdfoiulk
+# Optional
+github_totp_seed: ABCDEF1234567890 # Obtained via https://github.com/settings/two_factor_authentication/intro

--- a/config.example.yml
+++ b/config.example.yml
@@ -2,4 +2,4 @@
 github_username: tillson
 github_password: a8ueifjq4jkasdfoiulk
 # Optional
-github_totp_seed: ABCDEF1234567890 # Obtained via https://github.com/settings/two_factor_authentication/intro
+github_totp_seed: ABCDEF1234567890 # Obtained via https://github.com/settings/two_factor_authentication/verify

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-git/go-git/v5 v5.0.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/pquerna/otp v1.2.0
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/viper v1.6.3
 	github.com/waigani/diffparser v0.0.0-20190828052634-7391f219313d

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -112,6 +114,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.2.0 h1:/A3+Jn+cagqayeR3iHs/L62m5ue7710D35zl1zJ1kok=
+github.com/pquerna/otp v1.2.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -20,6 +20,7 @@ type Flags struct {
 	NoGists       bool
 	NoRepos       bool
 	ManyResults   bool
+	OTPCode       string
 }
 
 var flags Flags


### PR DESCRIPTION
## What's Changed?
* Added a new field in `GithubCredentials` to support the OTP code
* Added a new config line for your Github TOTP seed - Can generate codes from here
* Added a new CLI argument `--otp-code` to supply your 2FA code on program run
* Pulled in a new dependency `https://github.com/pquerna/otp` to handle TOTP generation
* Updated docs to reflect changes to `config.yml` and the new CLI argument

## Testing
I recommend creating a throwaway Github account in order to test this easier (otherwise you will need to redo your 2FA setup on your account to grab the TOTP Seed value). An image of where to click during the 2FA setup process is included below that lets you grab the raw TOTP seed value.
![chrome_3xBunOTTbO](https://user-images.githubusercontent.com/2565153/82160105-ceed9c80-9847-11ea-8e0f-ea93d4a0a594.png)

Update your `config.yml` with the new `github_totp_seed` field.
Run: `echo "test.com" | ./git-hound`

Comment out the new field in `config.yml`
Run: `echo "test.com" | ./git-hound --otp-code <code>`

Comment out the new field in `config.yml`
Run: `echo "test.com | ./git-hound` -- Ensure you are prompted for 2FA Code

## Why?
I was getting annoyed while using this and having to manually enter my 2FA code every time. This allows the user to have some flexibility with automatically generating a TOTP code or letting them supply it in the CLI. Worst case, they are just prompted for it.

Feel free to adjust things as needed.