### PR TITLE
Fixed the indexing issue of "args" and looking up secrets in a given repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.yml
+git-hound

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ func InitializeFlags() {
 	rootCmd.PersistentFlags().StringVar(&app.GetFlags().LanguageFile, "language-file", "", "Supply your own list of languages to search (java, python).")
 	rootCmd.PersistentFlags().StringVar(&app.GetFlags().ConfigFile, "config-file", "", "Supply the path to a config file.")
 	rootCmd.PersistentFlags().IntVar(&app.GetFlags().Pages, "pages", 100, "Maximum pages to search per query")
+	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().GithubRepo, "github-repo", false, "Search in a specific Github Repo only.")
 	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().ResultsOnly, "results-only", false, "Only print match strings.")
 	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().NoAPIKeys, "no-api-keys", false, "Don't search for generic API keys.")
 	rootCmd.PersistentFlags().BoolVar(&app.GetFlags().NoScoring, "no-scoring", false, "Don't use scoring to filter out false positives.")
@@ -108,7 +109,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func getScanner(args []string, cmd *cobra.Command) *bufio.Scanner {
+func getScanner(args []string) *bufio.Scanner {
 	if len(args) == 2 {
 		if args[0] == "searchKeyword" {
 			return bufio.NewScanner(strings.NewReader(args[1]))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,12 +108,13 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func getScanner(args []string) *bufio.Scanner {
-	if args[0] == "searchKeyword" {
-		return bufio.NewScanner(strings.NewReader(args[1]))
-	} else {
-		return bufio.NewScanner(os.Stdin)
+func getScanner(args []string, cmd *cobra.Command) *bufio.Scanner {
+	if len(args) == 2 {
+		if args[0] == "searchKeyword" {
+			return bufio.NewScanner(strings.NewReader(args[1]))
+		}
 	}
+	return bufio.NewScanner(os.Stdin)
 }
 
 // Execute command

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -9,6 +9,7 @@ type Flags struct {
 	LanguageFile  string
 	ConfigFile    string
 	Pages         int
+	GithubRepo    bool
 	ResultsOnly   bool
 	NoAPIKeys     bool
 	NoScoring     bool

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -80,7 +80,13 @@ func Search(query string, client *http.Client) (results []RepoSearchResult, err 
 func SearchGitHub(query string, options SearchOptions, client *http.Client, results *[]RepoSearchResult, resultSet map[string]bool) (err error) {
 	// TODO: A lot of this code is shared between GitHub and Gist searches,
 	// so we should rework the logic
-	base := "https://github.com/search"
+	base := ""
+	if GetFlags().GithubRepo {
+		base = "https://github.com/" + query + "/search"
+	} else {
+		base = "https://github.com/search"
+	}
+
 	page, pages := 0, 1
 	var delay = 5
 	orders := []string{"asc"}


### PR DESCRIPTION
- Since `args[0]` and `args[1]` were used without any proper check on the length of `args`, this was causing indexing issues when trying to execute git-hound with less than two CLI child commands.
    - This addresses the issue #39 
- Adding the feature to lookup secrets/patterns in a given Github Repository instead of generally searching Github.
    - This addresses the issue #40  